### PR TITLE
Removing Cleanup Resource

### DIFF
--- a/articles/active-directory-b2c/active-directory-b2c-quickstarts-desktop-app.md
+++ b/articles/active-directory-b2c/active-directory-b2c-quickstarts-desktop-app.md
@@ -95,10 +95,6 @@ The application includes the Azure AD access token in the request to the protect
 
 You have successfully used your Azure AD B2C user account to make an authorized call an Azure AD B2C protected web API.
 
-## Clean up resources
-
-You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C quickstarts or tutorials. When no longer needed, you can [delete your Azure AD B2C tenant](active-directory-b2c-faqs.md#how-do-i-delete-my-azure-ad-b2c-tenant).
-
 ## Next steps
 
 The next step is to create your own Azure AD B2C tenant and configure the sample to run using your tenant. 

--- a/articles/active-directory-b2c/active-directory-b2c-quickstarts-spa.md
+++ b/articles/active-directory-b2c/active-directory-b2c-quickstarts-spa.md
@@ -90,10 +90,6 @@ Click the **Call Web API** button to have your display name returned from the We
 
 The sample single-page app includes an Azure AD access token in the request to the protected web API resource to perform the operation to return the JSON object.
 
-## Clean up resources
-
-You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C quickstarts or tutorials. When no longer needed, you can [delete your Azure AD B2C tenant](active-directory-b2c-faqs.md#how-do-i-delete-my-azure-ad-b2c-tenant).
-
 ## Next steps
 
 In this quickstart, you used an Azure AD B2C enabled sample ASP.NET app to sign in with a custom login page, sign in with a social identity provider, create an Azure AD B2C account, and call a web API protected by Azure AD B2C. 

--- a/articles/active-directory-b2c/active-directory-b2c-quickstarts-web-app.md
+++ b/articles/active-directory-b2c/active-directory-b2c-quickstarts-web-app.md
@@ -109,10 +109,6 @@ Azure Active Directory B2C provides functionality to allow users to update their
 
 You have successfully used your Azure AD B2C user account to make an authorized call an Azure AD B2C protected web API.
 
-## Clean up resources
-
-You can use your Azure AD B2C tenant if you plan to try other Azure AD B2C quickstarts or tutorials. When no longer needed, you can [delete your Azure AD B2C tenant](active-directory-b2c-faqs.md#how-do-i-delete-my-azure-ad-b2c-tenant).
-
 ## Next steps
 
 In this quickstart, you used an Azure AD B2C enabled sample ASP.NET app to sign in with a custom login page, sign in with a social identity provider, create an Azure AD B2C account, and call a web API protected by Azure AD B2C. 


### PR DESCRIPTION
Quickstart tutorials do not create any Azure AD B2C tenants.  As result, the section on cleaning up any created tenant is not needed.